### PR TITLE
CI: Add Python 3.14 testing and update cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,10 +56,9 @@ jobs:
 
       - name: Build 
         # https://github.com/pypa/cibuildwheel
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
-          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           #https://cibuildwheel.pypa.io/en/stable/options/#archs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           #https://cibuildwheel.pypa.io/en/stable/options/#archs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.13", "3.14"]
 
     runs-on: ${{ matrix.os }}
-    
+
     env:
       CI: true
-    
+
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Set up Python 3.13
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.13"
+          python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
       
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
-          allow-prereleases: true
       
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
Updated CI/CD workflows to expand Python version testing and modernize build tooling.

## Key Changes
- **test.yml**: Added Python 3.14 to the test matrix alongside 3.13, enabling testing across multiple Python versions on all platforms (Ubuntu, Windows, macOS)
- **test.yml**: Parameterized the Python setup step to use the matrix variable instead of hardcoding version 3.13
- **publish.yml**: Updated cibuildwheel from v2.23.2 to v3.3.1 to support building wheels for Python 3.14
- **Formatting**: Fixed trailing whitespace in test.yml for consistency

## Implementation Details
The test matrix now dynamically runs tests for both Python 3.13 and 3.14 across all three operating systems, providing better coverage for the upcoming Python 3.14 release. The cibuildwheel upgrade ensures compatibility with the new Python version for wheel building.

https://claude.ai/code/session_01SEzYTNWMRtJvmGH1ntaPoo